### PR TITLE
[#73] Phase2 세팅

### DIFF
--- a/src/app/ai/coach/_components/ChatbotMessage.tsx
+++ b/src/app/ai/coach/_components/ChatbotMessage.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Box, Button, Flex, Stack, Text } from '@chakra-ui/react';
+
+interface ChatbotMessageProps {
+  message: string;
+  buttonText: string;
+  onButtonClick: () => void;
+}
+
+function ChatbotMessage({
+  message,
+  buttonText,
+  onButtonClick,
+}: ChatbotMessageProps) {
+  return (
+    <Stack direction="column" gap="8px" w="258px">
+      <Flex alignItems="center" gap="8px">
+        <Box boxSize="24px" bgColor="red.100" borderRadius="50%" />
+        <Text textStyle="mobile_cap" color="font.800">
+          AI 코치 재빗
+        </Text>
+      </Flex>
+      <Flex
+        bgColor="brand.white"
+        border="1.5px solid"
+        borderColor="gray.200"
+        borderRadius="20px"
+        px="12px"
+        py="16px"
+        gap="20px"
+        flexDirection="column"
+      >
+        <Text color="font.900" textStyle="mobile_b1_med">
+          {message}
+        </Text>
+        <Button
+          h="40px"
+          bgColor="blue.200"
+          borderRadius="10px"
+          onClick={onButtonClick}
+          color="blue.700"
+          textStyle="mobile_b1_semi"
+        >
+          {buttonText}
+        </Button>
+      </Flex>
+    </Stack>
+  );
+}
+
+export default ChatbotMessage;

--- a/src/app/ai/coach/_components/form/ProgressBar.tsx
+++ b/src/app/ai/coach/_components/form/ProgressBar.tsx
@@ -1,0 +1,16 @@
+import { Box } from '@chakra-ui/react';
+
+function ProgressBar({ progress }: { progress: number }) {
+  return (
+    <Box width="100%" height="8px" bgColor="brand.white" borderRadius="10px">
+      <Box
+        width={`${progress}%`}
+        height="100%"
+        bgColor="brand.blue"
+        borderRadius="10px"
+      />
+    </Box>
+  );
+}
+
+export default ProgressBar;

--- a/src/app/ai/coach/_components/form/Question.tsx
+++ b/src/app/ai/coach/_components/form/Question.tsx
@@ -1,0 +1,23 @@
+import { Stack, Text } from '@chakra-ui/react';
+
+interface QuestionProps {
+  title: string;
+  description?: string;
+}
+
+function Question({ title, description }: QuestionProps) {
+  return (
+    <Stack direction="column" gap="12px">
+      <Text textStyle="mobile_h1" color="font.900">
+        {title}
+      </Text>
+      {description && (
+        <Text textStyle="mobile_b1_semi" color="font.700">
+          {description}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+export default Question;

--- a/src/app/ai/coach/_components/form/Step.tsx
+++ b/src/app/ai/coach/_components/form/Step.tsx
@@ -1,0 +1,21 @@
+import { Flex, Text } from '@chakra-ui/react';
+
+interface StepProps {
+  currentStep: number;
+  totalStep: number;
+}
+
+function Step({ currentStep, totalStep }: StepProps) {
+  return (
+    <Flex gap="8px" alignItems="center">
+      <Text color="brand.blue" textStyle="mobile_d1_bold">
+        {currentStep}
+      </Text>
+      <Text color="font.600" textStyle="mobile_h2">
+        /{totalStep}
+      </Text>
+    </Flex>
+  );
+}
+
+export default Step;

--- a/src/app/ai/coach/_components/form/StepController.tsx
+++ b/src/app/ai/coach/_components/form/StepController.tsx
@@ -1,0 +1,55 @@
+import { Button, Flex } from '@chakra-ui/react';
+import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
+
+interface StepControllerProps {
+  currentStep: number;
+  totalStep: number;
+  onPrevStep: () => void;
+  onNextStep: () => void;
+}
+
+function StepController({
+  currentStep,
+  totalStep,
+  onPrevStep,
+  onNextStep,
+}: StepControllerProps) {
+  return (
+    <Flex gap="16px" alignItems="center">
+      <Button
+        p="0"
+        width="32px"
+        height="32px"
+        borderRadius="5px"
+        bgColor="brand.white"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        onClick={onPrevStep}
+        _disabled={{ opacity: 0.4 }}
+        disabled={currentStep === 1}
+        color="font.700"
+      >
+        <LuChevronLeft color="inherit" width="24px" height="24px" />
+      </Button>
+      <Button
+        p="0"
+        width="32px"
+        height="32px"
+        borderRadius="5px"
+        bgColor="brand.white"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        onClick={onNextStep}
+        _disabled={{ opacity: 0.4 }}
+        disabled={currentStep === totalStep}
+        color="font.700"
+      >
+        <LuChevronRight color="inherit" width="24px" height="24px" />
+      </Button>
+    </Flex>
+  );
+}
+
+export default StepController;

--- a/src/app/ai/coach/form/page.tsx
+++ b/src/app/ai/coach/form/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Box, Flex, Stack } from '@chakra-ui/react';
+import ProgressBar from '../_components/form/ProgressBar';
+import { useState } from 'react';
+import StepController from '../_components/form/StepController';
+import Step from '../_components/form/Step';
+import Question from '../_components/form/Question';
+
+const totalStep = 12;
+
+function CoachFormPage() {
+  const [currentStep, setCurrentStep] = useState(1);
+
+  const renderStepContent = () => {
+    switch (currentStep) {
+      case 1:
+        return (
+          <Question
+            title="10년 이내에 이루고 싶은 재무 목표는 무엇인가요?"
+            description="현재는 ‘내 집 마련’ 목표 설정만 도와드려요."
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box pt="60px">
+      <Stack direction="column" gap="36px" px="20px">
+        <ProgressBar progress={(currentStep / totalStep) * 100} />
+        <Flex alignItems="center" justifyContent="space-between">
+          <Step currentStep={currentStep} totalStep={totalStep} />
+          <StepController
+            currentStep={currentStep}
+            totalStep={totalStep}
+            onPrevStep={() => setCurrentStep(currentStep - 1)}
+            onNextStep={() => setCurrentStep(currentStep + 1)}
+          />
+        </Flex>
+
+        {/* step content */}
+        {renderStepContent()}
+      </Stack>
+    </Box>
+  );
+}
+
+export default CoachFormPage;

--- a/src/app/ai/coach/page.tsx
+++ b/src/app/ai/coach/page.tsx
@@ -1,5 +1,46 @@
+'use client';
+
+import { Stack } from '@chakra-ui/react';
+import ChatbotMessage from './_components/ChatbotMessage';
+import { useRouter } from 'next/navigation';
+
 function CoachPage() {
-  return <div>CoachPage</div>;
+  const { push } = useRouter();
+
+  return (
+    <Stack direction="column" gap="20px" px="20px">
+      <ChatbotMessage
+        message="이번 주 재무리포트가 도착했어요."
+        buttonText="확인하기"
+        onButtonClick={() => push('/ai/coach/form')}
+      />
+      <ChatbotMessage
+        message="전문가의 코칭 보고서가 도착했어요."
+        buttonText="확인하기"
+        onButtonClick={() => console.log('코칭 보고서 확인하기')}
+      />
+      <ChatbotMessage
+        message="목표를 이루기 위한 루틴이 도착했어요. 작지만 꾸준히 실천할 수 있는 루틴을 추천드려요."
+        buttonText="읽어보기"
+        onButtonClick={() => console.log('루틴 읽어보기')}
+      />
+      <ChatbotMessage
+        message="이번 주 재무리포트가 도착했어요."
+        buttonText="확인하기"
+        onButtonClick={() => console.log('재무리포트 확인하기')}
+      />
+      <ChatbotMessage
+        message="전문가의 코칭 보고서가 도착했어요."
+        buttonText="확인하기"
+        onButtonClick={() => console.log('코칭 보고서 확인하기')}
+      />
+      <ChatbotMessage
+        message="목표를 이루기 위한 루틴이 도착했어요. 작지만 꾸준히 실천할 수 있는 루틴을 추천드려요."
+        buttonText="읽어보기"
+        onButtonClick={() => console.log('루틴 읽어보기')}
+      />
+    </Stack>
+  );
 }
 
 export default CoachPage;

--- a/src/app/ai/coach/page.tsx
+++ b/src/app/ai/coach/page.tsx
@@ -1,0 +1,5 @@
+function CoachPage() {
+  return <div>CoachPage</div>;
+}
+
+export default CoachPage;

--- a/src/app/ai/layout.tsx
+++ b/src/app/ai/layout.tsx
@@ -1,0 +1,20 @@
+import { Box, Flex } from '@chakra-ui/react';
+
+function MobileLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <Flex justifyContent="center" alignItems="center" height="100vh">
+      <Box maxWidth="480px" width="100%" height="100vh" bgColor="gray.100">
+        <Box
+          width="100%"
+          height="100%"
+          bgColor="app_background"
+          overflowY="scroll"
+        >
+          {children}
+        </Box>
+      </Box>
+    </Flex>
+  );
+}
+
+export default MobileLayout;

--- a/src/app/ai/money-tracker/page.tsx
+++ b/src/app/ai/money-tracker/page.tsx
@@ -1,0 +1,5 @@
+function MoneyTrackerPage() {
+  return <div>MoneyTrackerPage</div>;
+}
+
+export default MoneyTrackerPage;

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation';
+
+function AIMainPage() {
+  redirect('/ai/coach');
+}
+
+export default AIMainPage;

--- a/src/app/ai/routine/page.tsx
+++ b/src/app/ai/routine/page.tsx
@@ -1,0 +1,5 @@
+function RoutinePage() {
+  return <div>RoutinePage</div>;
+}
+
+export default RoutinePage;

--- a/src/client/theme/colors.ts
+++ b/src/client/theme/colors.ts
@@ -1,0 +1,66 @@
+export const COLORS = {
+  red: {
+    100: { value: '#FEE8E5' },
+    200: { value: '#B86358' },
+    300: { value: '#D24040' },
+  },
+  yellow: {
+    100: { value: '#FFFCF0' },
+    200: { value: '#FFF3C7' },
+  },
+  brown: {
+    100: { value: '#B0AB9A' },
+    200: { value: '#93844F' },
+  },
+  green: {
+    100: { value: '#D8F3DD' },
+    200: { value: '#D1ECC5' },
+    300: { value: '#798C71' },
+    400: { value: '#1F7F31' },
+    500: { value: '#30B94B' },
+  },
+  blue: {
+    100: { value: '#F8F9FC' },
+    200: { value: '#F3F5FF' },
+    300: { value: '#E8EBFF' },
+    400: { value: '#DFE3FD' },
+    500: { value: '#C2C6DF' },
+    600: { value: '#9DA4C6' },
+    700: { value: '#7C83B0' },
+    800: { value: '#5971B2' },
+  },
+  blue_gray: {
+    100: { value: '#EAEAF1' },
+    200: { value: '#E1E1EB' },
+    300: { value: '#A9ABBC' },
+    400: { value: '#83889F' },
+  },
+  brand: {
+    white: { value: '#fff' },
+    black: { value: '#211E1C' },
+    blue: { value: '#334195' },
+    green: { value: '#4D8B31' },
+    yellow: { value: '#FFC800' },
+  },
+  graph: {
+    teal: { value: '#1D5E70' },
+    yellow_green: { value: '#D1F0B5' },
+    coral: { value: '#F0A57D' },
+    violet: { value: '#5751BE' },
+    yellow: { value: '#FBDE8C' },
+  },
+  font: {
+    300: { value: '#DFDFDF' },
+    400: { value: '#D9D9D9' },
+    500: { value: '#C3C2C2' },
+    600: { value: '#A3A3A3' },
+    700: { value: '#868686' },
+    800: { value: '#5D5D5D' },
+    900: { value: '#222' },
+    required: { value: '#E64E4E' },
+  },
+  line: {
+    gray: { value: '#F2F3F5' },
+  },
+  app_background: { value: '#F5F6F9' },
+};

--- a/src/client/theme/textStyle.ts
+++ b/src/client/theme/textStyle.ts
@@ -1,0 +1,173 @@
+export const MOBILE_TEXT_STYLE = {
+  mobile_d1_bold: {
+    value: {
+      fontSize: '36px',
+      fontWeight: 700,
+      lineHeight: '130%',
+    },
+  },
+  mobile_h1: {
+    value: {
+      fontSize: '24px',
+      fontWeight: 700,
+      lineHeight: '130%',
+    },
+  },
+  mobile_h2: {
+    value: {
+      fontSize: '20px',
+      fontWeight: 700,
+      lineHeight: '130%',
+    },
+  },
+  mobile_h3: {
+    value: {
+      fontSize: '18px',
+      fontWeight: 600,
+      lineHeight: '140%',
+    },
+  },
+  mobile_b1_semi: {
+    value: {
+      fontSize: '16px',
+      fontWeight: 600,
+      lineHeight: '140%',
+    },
+  },
+  mobile_b1_med: {
+    value: {
+      fontSize: '16px',
+      fontWeight: 500,
+      lineHeight: '140%',
+    },
+  },
+  mobile_b2: {
+    value: {
+      fontSize: '14px',
+      fontWeight: 600,
+      lineHeight: '140%',
+    },
+  },
+  mobile_cap: {
+    value: {
+      fontSize: '12px',
+      fontWeight: 500,
+      lineHeight: '130%',
+    },
+  },
+};
+
+export const WEB_TEXT_STYLE = {
+  web_h1: {
+    value: {
+      fontSize: '44px',
+      fontWeight: 600,
+      lineHeight: '53px',
+    },
+  },
+  web_h2: {
+    value: {
+      fontSize: '38px',
+      fontWeight: 600,
+      lineHeight: '45px',
+    },
+  },
+  web_h3: {
+    value: {
+      fontSize: '28px',
+      fontWeight: 600,
+      lineHeight: '33px',
+    },
+  },
+  web_h4: {
+    value: {
+      fontSize: '24px',
+      fontWeight: 600,
+      lineHeight: '29px',
+    },
+  },
+  web_h5: {
+    value: {
+      fontSize: '20px',
+      fontWeight: 600,
+      lineHeight: '24px',
+    },
+  },
+  web_b1: {
+    value: {
+      fontSize: '28px',
+      fontWeight: 500,
+      lineHeight: '33px',
+    },
+  },
+  web_b2: {
+    value: {
+      fontSize: '22px',
+      fontWeight: 500,
+      lineHeight: '25px',
+    },
+  },
+  web_b3: {
+    value: {
+      fontSize: '20px',
+      fontWeight: 500,
+      lineHeight: '24px',
+    },
+  },
+  web_b4_semi: {
+    value: {
+      fontSize: '18px',
+      fontWeight: 600,
+      lineHeight: '21px',
+    },
+  },
+  web_b4_med: {
+    value: {
+      fontSize: '18px',
+      fontWeight: 500,
+      lineHeight: '21px',
+    },
+  },
+  web_b5_semi: {
+    value: {
+      fontSize: '16px',
+      fontWeight: 600,
+      lineHeight: '19px',
+    },
+  },
+  web_b5_med: {
+    value: {
+      fontSize: '16px',
+      fontWeight: 500,
+      lineHeight: '19px',
+    },
+  },
+  web_b6_semi: {
+    value: {
+      fontSize: '14px',
+      fontWeight: 600,
+      lineHeight: '17px',
+    },
+  },
+  web_b6_med: {
+    value: {
+      fontSize: '14px',
+      fontWeight: 500,
+      lineHeight: '17px',
+    },
+  },
+  web_b6_reg: {
+    value: {
+      fontSize: '14px',
+      fontWeight: 400,
+      lineHeight: '17px',
+    },
+  },
+  web_tag: {
+    value: {
+      fontSize: '12px',
+      fontWeight: 700,
+      lineHeight: '14px',
+    },
+  },
+};

--- a/src/client/theme/theme.ts
+++ b/src/client/theme/theme.ts
@@ -4,8 +4,12 @@ import {
   defineConfig,
   defineTextStyles,
 } from '@chakra-ui/react';
+import { COLORS } from './colors';
+import { WEB_TEXT_STYLE, MOBILE_TEXT_STYLE } from './textStyle';
 
 export const textStyles = defineTextStyles({
+  ...WEB_TEXT_STYLE,
+  ...MOBILE_TEXT_STYLE,
   xs: {
     value: {
       fontSize: '14px',
@@ -49,6 +53,7 @@ const customConfig = defineConfig({
     textStyles,
     tokens: {
       colors: {
+        ...COLORS,
         primary: {
           value: '#334195',
         },


### PR DESCRIPTION
### 개요

- close #73 

---

### 작업 내용

- [ ] textStyle, color 추가
- [ ] phase2에 필요한 페이지들 추가 
- [ ] 모바일 레이아웃 
- [ ] 컴포넌트 추가 : chatbotMessage / step, stepController, question, progessbar 

---

### 스크린샷

---

### 참고

- 정의한 컬러, 텍스트 스타일은 `yarn theme` 하면 자동완성될거에용! 
    - 사용방법 :  ex.) `<Text textStyle="mobile_cap" color="font.800">`
- 모바일 레이아웃에 헤더 영역과 네비게이션 영역은 배제했습니다. 추후 디자인 나오면 넣을게용 
- phase2에 해당하는 페이지들은 /ai 하위에 들어가서 따로 그룹핑하지는 않았어요. 
- ai/coach/form에 보면 제가 임의로 넣은 설문 UI 보실 수 있는데 마음에 안드시면 미정님께서 재정의 해주셔도 됩니다! 
