### PR TITLE
[#83-1] 로그인 redirectTo 추가

### DIFF
--- a/src/app/ai/login/page.tsx
+++ b/src/app/ai/login/page.tsx
@@ -12,12 +12,11 @@ import { OAUTH } from '@/src/client/config/auth';
 const handleKakaoLogin = () => {
   const redirectTo = '/ai';
   const statePayload = {
-    csrfToken: uuidv4(),
     redirectTo,
   };
 
   const state = encodeURIComponent(btoa(JSON.stringify(statePayload)));
-  window.location.href = `${OAUTH.KAKAO.AUTH_URL}&state=${state}`;
+  window.location.href = OAUTH.KAKAO.AUTH_URL(state);
 };
 
 const handleNaverLogin = () => {
@@ -28,7 +27,7 @@ const handleNaverLogin = () => {
   };
 
   const state = encodeURIComponent(btoa(JSON.stringify(statePayload)));
-  window.location.href = `${OAUTH.NAVER.AUTH_URL}&state=${state}`;
+  window.location.href = OAUTH.NAVER.AUTH_URL(state);
 };
 
 const Login = () => {

--- a/src/app/api/auth/token/route.ts
+++ b/src/app/api/auth/token/route.ts
@@ -13,7 +13,15 @@ export async function POST(request: Request) {
       return createErrorApiResponse('INVALID_USER_DATA');
     }
 
-    const token = jwt.sign(user, JWT.SECRET, {
+    const payload = {
+      sub: user.id,
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      auth: 'ROLE_USER',
+    };
+
+    const token = jwt.sign(payload, JWT.SECRET, {
       expiresIn: JWT.EXPIRES_IN,
     });
 

--- a/src/app/auth/kakao/components/AuthPageContent.tsx
+++ b/src/app/auth/kakao/components/AuthPageContent.tsx
@@ -11,6 +11,8 @@ import { AuthUser } from '@/src/client/store/authStore';
 const AuthPageContent = () => {
   const router = useRouter();
   const code = useSearchParams().get('code');
+  const state = useSearchParams().get('state');
+
   const { setUser } = useAuthStore();
   const { showErrorToast } = useErrorToast();
   const [isFetching, setIsFetching] = useState(false);
@@ -31,8 +33,12 @@ const AuthPageContent = () => {
         email: data.email ?? 'Unknown',
       };
       const token = await createJwtToken(user);
+      const decodedState = state
+        ? JSON.parse(atob(decodeURIComponent(state ?? '')))
+        : null;
+
       setUser(user, token);
-      router.replace('/');
+      router.replace(decodedState?.redirectTo || '/');
     } else {
       // 신규 유저일 경우 회원가입 페이지로 라우팅
       router.replace(

--- a/src/app/auth/naver/components/AuthPageContent.tsx
+++ b/src/app/auth/naver/components/AuthPageContent.tsx
@@ -52,7 +52,6 @@ const AuthPageContent = () => {
       setExecutedCode(code);
       setIsFetching(true);
 
-      const state = localStorage.getItem('naverState');
       fetch(`/api/auth/naver/callback?code=${code}&state=${state}`)
         .then(async (res) => {
           const response = await res.json();

--- a/src/app/auth/naver/components/AuthPageContent.tsx
+++ b/src/app/auth/naver/components/AuthPageContent.tsx
@@ -1,15 +1,18 @@
-import { Flex, Text } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Flex, Text, Spinner } from '@chakra-ui/react';
+
+import { createJwtToken } from '@/src/client/lib/api/createJwt';
 import { AppError } from '@/src/client/errors/AppError';
 import { useErrorToast } from '@/src/client/errors/useErrorToast';
 import { useAuthStore } from '@/src/client/store/authStore';
-import { Spinner } from '@chakra-ui/react';
-import { useSearchParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
-import { createJwtToken } from '@/src/client/lib/api/createJwt';
 import { AuthUser } from '@/src/client/store/authStore';
+
 const AuthPageContent = () => {
   const router = useRouter();
   const code = useSearchParams().get('code');
+  const state = useSearchParams().get('state');
+
   const { setUser: setUser } = useAuthStore();
   const { showErrorToast } = useErrorToast();
   const [executedCode, setExecutedCode] = useState<string | null>(null);
@@ -30,8 +33,12 @@ const AuthPageContent = () => {
         email: data.email ?? 'Unknown',
       };
       const token = await createJwtToken(user);
+      const decodedState = state
+        ? JSON.parse(atob(decodeURIComponent(state ?? '')))
+        : null;
+
       setUser(user, token);
-      router.replace('/');
+      router.replace(decodedState.redirectTo || '/');
     } else {
       // 신규 유저일 경우 회원가입 페이지로 라우팅
       router.replace(

--- a/src/app/components/AuthBtn/LoginBtn.tsx
+++ b/src/app/components/AuthBtn/LoginBtn.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { Button } from '@chakra-ui/react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
 const LoginBtn = () => {
   const router = useRouter();
+  const pathname = usePathname();
 
   const handleLogin = () => {
-    router.push('/login');
+    router.push(`/login?redirectTo=${pathname}`);
   };
 
   return (

--- a/src/app/login/Login.tsx
+++ b/src/app/login/Login.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { v4 as uuidv4 } from 'uuid';
+import { Box, Flex, Text } from '@chakra-ui/react';
+
+import KakaoLoginBtnSVG from '@/public/assets/KakaoLoginBtn.svg';
+import NaverLoginBtnSVG from '@/public/assets/NaverLoginBtn.svg';
+import { TERMS_OF_SERVICE_URL } from '@/src/client/constants/URL';
+import { PRIVACY_POLICY_URL } from '@/src/client/constants/URL';
+import { OAUTH } from '@/src/client/config/auth';
+
+import Footer from '../components/Footer/Footer';
+import Logo from '../common/Logo/Logo';
+import BaseLink from '../common/BaseLink/BaseLink';
+
+const Login = () => {
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get('redirectTo');
+
+  const handleKakaoLogin = () => {
+    const statePayload = {
+      redirectTo,
+    };
+
+    const state = encodeURIComponent(btoa(JSON.stringify(statePayload)));
+    window.location.href = OAUTH.KAKAO.AUTH_URL(state);
+  };
+
+  const handleNaverLogin = () => {
+    const statePayload = {
+      redirectTo,
+      csrfToken: uuidv4(),
+    };
+
+    const state = encodeURIComponent(btoa(JSON.stringify(statePayload)));
+    window.location.href = OAUTH.NAVER.AUTH_URL(state);
+  };
+
+  return (
+    <Flex width="100%" height="100vh" flexDirection="column">
+      <Box width="1920px" padding="38px 320px" borderTop="2px solid #f2f3f5">
+        <Logo />
+      </Box>
+      <Flex mx="auto" width="100%" height="100%" flexDirection="column">
+        <Flex
+          height="100%"
+          width="100%"
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+        >
+          <Text fontSize="40px" fontWeight="600" color="main.black_1">
+            로그인 / 회원가입
+          </Text>
+          <Flex flexDirection="column" gap="20px" mt="52px">
+            <KakaoLoginBtnSVG onClick={handleKakaoLogin} cursor="pointer" />
+            <NaverLoginBtnSVG onClick={handleNaverLogin} cursor="pointer" />
+          </Flex>
+          <Text
+            fontSize="16px"
+            fontWeight="400"
+            color="main.black_2"
+            mt="36px"
+            textAlign="center"
+            maxWidth="333px"
+            wordBreak="keep-all"
+          >
+            신규 회원가입시{' '}
+            <BaseLink href={TERMS_OF_SERVICE_URL}>서비스 이용 약관</BaseLink> 및{' '}
+            <BaseLink href={PRIVACY_POLICY_URL}>개인정보 수집</BaseLink>에
+            동의한 것으로 간주됩니다.
+          </Text>
+        </Flex>
+      </Flex>
+      <Footer />
+    </Flex>
+  );
+};
+
+export default Login;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,27 +1,42 @@
 'use client';
 
-import { Box, Flex, Text } from '@chakra-ui/react';
+import { useSearchParams } from 'next/navigation';
 import { v4 as uuidv4 } from 'uuid';
+import { Box, Flex, Text } from '@chakra-ui/react';
+
 import KakaoLoginBtnSVG from '@/public/assets/KakaoLoginBtn.svg';
 import NaverLoginBtnSVG from '@/public/assets/NaverLoginBtn.svg';
-import { OAUTH } from '@/src/client/config/auth';
-import Footer from '../components/Footer/Footer';
-import Logo from '../common/Logo/Logo';
 import { TERMS_OF_SERVICE_URL } from '@/src/client/constants/URL';
 import { PRIVACY_POLICY_URL } from '@/src/client/constants/URL';
+import { OAUTH } from '@/src/client/config/auth';
+
+import Footer from '../components/Footer/Footer';
+import Logo from '../common/Logo/Logo';
 import BaseLink from '../common/BaseLink/BaseLink';
 
-const handleKakaoLogin = () => {
-  window.location.href = OAUTH.KAKAO.AUTH_URL;
-};
-
-const handleNaverLogin = () => {
-  const naverState = uuidv4();
-  localStorage.setItem('naverState', naverState);
-  window.location.href = OAUTH.NAVER.AUTH_URL(naverState);
-};
-
 const Login = () => {
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get('redirectTo');
+
+  const handleKakaoLogin = () => {
+    const statePayload = {
+      redirectTo,
+    };
+
+    const state = encodeURIComponent(btoa(JSON.stringify(statePayload)));
+    window.location.href = OAUTH.KAKAO.AUTH_URL(state);
+  };
+
+  const handleNaverLogin = () => {
+    const statePayload = {
+      redirectTo,
+      csrfToken: uuidv4(),
+    };
+
+    const state = encodeURIComponent(btoa(JSON.stringify(statePayload)));
+    window.location.href = OAUTH.NAVER.AUTH_URL(state);
+  };
+
   return (
     <Flex width="100%" height="100vh" flexDirection="column">
       <Box width="1920px" padding="38px 320px" borderTop="2px solid #f2f3f5">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,81 +1,13 @@
-'use client';
+import { Suspense } from 'react';
+import { Spinner } from '@chakra-ui/react';
+import Login from './Login';
 
-import { useSearchParams } from 'next/navigation';
-import { v4 as uuidv4 } from 'uuid';
-import { Box, Flex, Text } from '@chakra-ui/react';
-
-import KakaoLoginBtnSVG from '@/public/assets/KakaoLoginBtn.svg';
-import NaverLoginBtnSVG from '@/public/assets/NaverLoginBtn.svg';
-import { TERMS_OF_SERVICE_URL } from '@/src/client/constants/URL';
-import { PRIVACY_POLICY_URL } from '@/src/client/constants/URL';
-import { OAUTH } from '@/src/client/config/auth';
-
-import Footer from '../components/Footer/Footer';
-import Logo from '../common/Logo/Logo';
-import BaseLink from '../common/BaseLink/BaseLink';
-
-const Login = () => {
-  const searchParams = useSearchParams();
-  const redirectTo = searchParams.get('redirectTo');
-
-  const handleKakaoLogin = () => {
-    const statePayload = {
-      redirectTo,
-    };
-
-    const state = encodeURIComponent(btoa(JSON.stringify(statePayload)));
-    window.location.href = OAUTH.KAKAO.AUTH_URL(state);
-  };
-
-  const handleNaverLogin = () => {
-    const statePayload = {
-      redirectTo,
-      csrfToken: uuidv4(),
-    };
-
-    const state = encodeURIComponent(btoa(JSON.stringify(statePayload)));
-    window.location.href = OAUTH.NAVER.AUTH_URL(state);
-  };
-
+function LoginPage() {
   return (
-    <Flex width="100%" height="100vh" flexDirection="column">
-      <Box width="1920px" padding="38px 320px" borderTop="2px solid #f2f3f5">
-        <Logo />
-      </Box>
-      <Flex mx="auto" width="100%" height="100%" flexDirection="column">
-        <Flex
-          height="100%"
-          width="100%"
-          flexDirection="column"
-          justifyContent="center"
-          alignItems="center"
-        >
-          <Text fontSize="40px" fontWeight="600" color="main.black_1">
-            로그인 / 회원가입
-          </Text>
-          <Flex flexDirection="column" gap="20px" mt="52px">
-            <KakaoLoginBtnSVG onClick={handleKakaoLogin} cursor="pointer" />
-            <NaverLoginBtnSVG onClick={handleNaverLogin} cursor="pointer" />
-          </Flex>
-          <Text
-            fontSize="16px"
-            fontWeight="400"
-            color="main.black_2"
-            mt="36px"
-            textAlign="center"
-            maxWidth="333px"
-            wordBreak="keep-all"
-          >
-            신규 회원가입시{' '}
-            <BaseLink href={TERMS_OF_SERVICE_URL}>서비스 이용 약관</BaseLink> 및{' '}
-            <BaseLink href={PRIVACY_POLICY_URL}>개인정보 수집</BaseLink>에
-            동의한 것으로 간주됩니다.
-          </Text>
-        </Flex>
-      </Flex>
-      <Footer />
-    </Flex>
+    <Suspense fallback={<Spinner size="xl" />}>
+      <Login />
+    </Suspense>
   );
-};
+}
 
-export default Login;
+export default LoginPage;

--- a/src/client/config/auth.ts
+++ b/src/client/config/auth.ts
@@ -1,6 +1,7 @@
 export const OAUTH = {
   KAKAO: {
-    AUTH_URL: `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&response_type=code`,
+    AUTH_URL: (state?: string) =>
+      `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&response_type=code&state=${state}`,
     TOKEN_URL: 'https://kauth.kakao.com/oauth/token',
     USER_INFO_URL: 'https://kapi.kakao.com/v2/user/me',
   },

--- a/src/client/config/jwt.ts
+++ b/src/client/config/jwt.ts
@@ -3,6 +3,6 @@ import { Secret } from 'jsonwebtoken';
 export const JWT_EXPIRES_IN = '3d';
 
 export const JWT = {
-  SECRET: process.env.JWT_SECRET as Secret,
+  SECRET: Buffer.from(process.env.JWT_SECRET as string, 'base64') as Secret,
   EXPIRES_IN: JWT_EXPIRES_IN,
 } as const;


### PR DESCRIPTION
### 개요

- #83 

---

### 작업 내용

- [x] phase1 로그인 성공시 : 로그인 이전 페이지로 이동
- [x] phase2 로그인 성공시 : /ai 메인으로 이동

---

### 스크린샷

---

### 참고
- phase 1 로그인 : 로그인 버튼 클릭시 로그인 페이지로 이동하면서 redirectTo로 현재 페이지 주소를 넘겨줍니다.
- phase 2 로그인 : 로그인 버튼이 별도로 없고 로그인안한 유저는 /ai에 진입을 못하기 때문에  /ai/login 페이지로 이동하고 별도로 redirectTo를 searchParam으로 넘겨주지 않고 redirectTo = '/ai'로 하드코딩해서 들어갔습니다.

- 공통로직 : state값에 encoding해서 들어갔습니다! 
   - 카카오는 기존에 state값이 없어서 naver처럼 state가 들어갈 수 있도록 변경
   - naver에는 기존에 들어가있던 csrfToken과 같이 redirectTo 값이 추가되어서 같이 encoding하였음다. 
     -> 기존에 localStorage에 naverState 저장했던 로직은 삭제
   - encoding한값은 AuthPageContent에서 router.replace할때 decode해서 redirectTo를 가져와서 넣어줍니다! 

++ 궁금한점 : naver에 redirectTo와 csrfToken이 모두 state로 들어가는데 로그인하는데는 문제가 없더라구요.. 왜인지는 모르겠는데 대훈님께서 사이드이팩트 더블체킹 해주시면 감사하겠습니다! 