### PR TITLE
[#82] AI 컨텐츠 생성 페이지2 - API 연동

### DIFF
--- a/src/app/ai/_constants/routes.ts
+++ b/src/app/ai/_constants/routes.ts
@@ -40,10 +40,6 @@ export const ROUTES: Record<
   // 코치
   COACH_MAIN: {
     path: '/ai/coach',
-    header: {
-      title: 'AI 코치 재빗',
-      hasPrev: false,
-    },
     hasNav: true,
     pageBgColor: 'white',
     mobileBgColor: 'app_background',
@@ -85,7 +81,7 @@ export const ROUTES: Record<
   COACH_ROUTINE: {
     path: '/ai/coach/routine',
     header: {
-      title: 'routine',
+      title: '루틴',
       hasPrev: true,
     },
     hasNav: false,

--- a/src/app/ai/_constants/routes.ts
+++ b/src/app/ai/_constants/routes.ts
@@ -85,7 +85,7 @@ export const ROUTES: Record<
   COACH_ROUTINE: {
     path: '/ai/coach/routine',
     header: {
-      title: '루틴',
+      title: 'routine',
       hasPrev: true,
     },
     hasNav: false,

--- a/src/app/ai/coach/[topic]/page.tsx
+++ b/src/app/ai/coach/[topic]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { Button, Text, Flex, Box } from '@chakra-ui/react';
 import Image from 'next/image';
+import { useGenerateAiSolutionStore } from '@/src/app/ai/coach/_store/generateAISolutionStore';
 
 export default function GuidePage() {
   const { topic } = useParams();
@@ -17,6 +18,9 @@ export default function GuidePage() {
   const [data, setData] = useState<any>(null);
   const [buttonText, setButtonText] = useState('');
 
+  const { setPlanRequested, setRoutineRequested } =
+    useGenerateAiSolutionStore();
+
   const buttonTextMap: Record<string, string> = {
     scenario: '시나리오 추가하기',
     plan: '플랜으로 설정하기',
@@ -24,7 +28,15 @@ export default function GuidePage() {
   };
 
   const handleButtonClick = () => {
-    push('/ai/coach');
+    if (topicStr === 'scenario') {
+      setPlanRequested();
+      push('/ai/coach');
+    } else if (topicStr === 'plan') {
+      setRoutineRequested();
+      push('/ai/coach');
+    } else if (topicStr === 'routine') {
+      // 페이지 이동
+    }
   };
 
   useEffect(() => {

--- a/src/app/ai/coach/[topic]/page.tsx
+++ b/src/app/ai/coach/[topic]/page.tsx
@@ -4,28 +4,100 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { Button, Text, Flex, Box } from '@chakra-ui/react';
+import { keyframes } from '@emotion/react';
 import Image from 'next/image';
-import { useGenerateAiSolutionStore } from '@/src/app/ai/coach/_store/generateAISolutionStore';
+import { useGenerateAiSolutionStore } from '@/src/app/ai/coach/_store/generateAiSolutionStore';
+
+function Loading({ message }: { message: string }) {
+  const typing = keyframes`
+  from { width: 0 }
+  to { width: ${message.length}ch }
+`;
+
+  const blink = keyframes`
+  0%, 100% { border-color: transparent }
+  50% { border-color: black }
+`;
+
+  const blinkImage = keyframes`
+  0%, 100% { opacity: 1 }
+  50% { opacity: 0 }
+`;
+  return (
+    <Flex
+      align="center"
+      gap="8px"
+      padding="24px 30px"
+      justifyContent="flex-start"
+    >
+      <Box animation={`${blinkImage} 2s ease-in-out infinite`}>
+        <Image
+          src="/assets/ico_money.svg"
+          alt="돈 아이콘"
+          width={24}
+          height={24}
+          priority={false}
+          style={{ objectFit: 'contain' }}
+        />
+      </Box>
+
+      <Text
+        textStyle="mobile_b2"
+        color="font.800"
+        whiteSpace="nowrap"
+        overflow="hidden"
+        borderRight="1px solid"
+        animation={`${typing} 3s steps(${message.length}), ${blink} 1s step-end infinite`}
+      >
+        {message}
+      </Text>
+    </Flex>
+  );
+}
 
 export default function GuidePage() {
   const { topic } = useParams();
   const { push } = useRouter();
-
   const topicStr = typeof topic === 'string' ? topic : '';
-  console.log('topic', topic);
-
-  const [loading, setLoading] = useState(true);
-  const [data, setData] = useState<any>(null);
-  const [buttonText, setButtonText] = useState('');
-
-  const { setPlanRequested, setRoutineRequested } =
-    useGenerateAiSolutionStore();
-
   const buttonTextMap: Record<string, string> = {
     scenario: '시나리오 추가하기',
     plan: '플랜으로 설정하기',
     routine: '루틴으로 설정하기',
   };
+  const topicKrMap: Record<string, string> = {
+    scenario: '시나리오를',
+    plan: '플랜을',
+    routine: '루틴을',
+  };
+
+  const loadingMessage = `재무코치가 나만을 위한 ${topicKrMap[topicStr]} 만들고 있어요...`;
+  const [data, setData] = useState<any>(null);
+
+  const { setPlanRequested, setRoutineRequested } =
+    useGenerateAiSolutionStore();
+
+  const [typingDone, setTypingDone] = useState(false);
+  console.log('loadingMessage', loadingMessage);
+
+  useEffect(() => {
+    if (!topicStr) return;
+
+    const fetchData = async () => {
+      try {
+        const response = await Promise.all([
+          // fetch(`/api/coach/guide/${topicStr}`).then((res) => res.json()),
+          new Promise((resolve) => setTimeout(resolve, 5000)),
+        ]);
+        setData('abc');
+        setTypingDone(true);
+      } catch (error) {
+        console.error('Error fetching guide:', error);
+      } finally {
+      }
+    };
+
+    fetchData();
+  }, [buttonTextMap, topicStr]);
 
   const handleButtonClick = () => {
     if (topicStr === 'scenario') {
@@ -39,52 +111,12 @@ export default function GuidePage() {
     }
   };
 
-  useEffect(() => {
-    if (!topicStr) return;
-
-    setButtonText(buttonTextMap[topicStr] || '');
-
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        const response = await fetch(`/api/coach/guide/${topicStr}`);
-        const result = await response.json();
-        setData(result);
-      } catch (error) {
-        console.error('Error fetching guide:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [buttonTextMap, topicStr]);
-
-  if (loading)
-    return (
-      <Flex
-        align="center"
-        gap="8px"
-        padding="24px 30px"
-        justifyContent="flex-start"
-      >
-        <Image
-          src="/assets/ico_money.svg"
-          alt="돈 아이콘"
-          width={24}
-          height={24}
-        />
-        <Text textStyle="mobile_b2" color="font.800">
-          재무코치가 나만을 위한 플랜을 만들고 있어요...
-        </Text>
-      </Flex>
-    );
-  //   if (!data) return <p>No data found for topic: {topicStr}</p>;
+  if (!typingDone) return <Loading message={loadingMessage} />;
 
   return (
     <Box>
       <Box px="20px" rounded="md" mt="16px">
-        <pre>{JSON.stringify(data)}</pre>
+        {/* <pre>{JSON.stringify(data)}</pre> */}
       </Box>
       <Button
         position="fixed"
@@ -101,7 +133,7 @@ export default function GuidePage() {
         onClick={handleButtonClick}
       >
         <Text textStyle="mobile_b1_semi" color="white">
-          {buttonText}
+          {buttonTextMap[topicStr]}
         </Text>
       </Button>
     </Box>

--- a/src/app/ai/coach/_components/ChatbotMessage.tsx
+++ b/src/app/ai/coach/_components/ChatbotMessage.tsx
@@ -34,7 +34,7 @@ function ChatbotMessage({
       <Flex
         bgColor="brand.white"
         border="1.5px solid"
-        borderColor="gray.200"
+        borderColor="line.gray"
         borderRadius="20px"
         px="12px"
         py="16px"

--- a/src/app/ai/coach/_components/form/Answer.tsx
+++ b/src/app/ai/coach/_components/form/Answer.tsx
@@ -61,7 +61,11 @@ function Answer({
   const renderAnswerChoices = () => {
     switch (type) {
       case 'choice-full':
-        return renderChoiceButtons(answerChoices);
+        return (
+          <Stack direction="column" minH="305px">
+            {renderChoiceButtons(answerChoices)}
+          </Stack>
+        );
 
       case 'choice-grid':
         const regionChoices = getRegionChoices();

--- a/src/app/ai/coach/_components/form/AnswerButton.tsx
+++ b/src/app/ai/coach/_components/form/AnswerButton.tsx
@@ -13,18 +13,23 @@ function AnswerButton({
     <Button
       borderRadius="10px"
       height="60px"
-      colorScheme={isSelected ? 'blue' : 'gray'}
-      variant={isSelected ? 'solid' : 'outline'}
       color="gray.700"
-      backgroundColor={isSelected ? 'blue.300' : 'white'}
       borderWidth="2px"
-      borderColor={isSelected ? 'brand.blue' : 'gray.100'}
+      backgroundColor="white"
+      borderColor="gray.100"
       _hover={{
-        backgroundColor: isSelected ? 'blue.300' : 'blue.300',
-        color: isSelected ? 'brand.blue' : 'gray.800',
+        backgroundColor: 'blue.300',
+        color: 'brand.blue',
         borderWidth: '2px',
         borderColor: 'brand.blue',
       }}
+      _selected={{
+        backgroundColor: 'blue.300',
+        color: 'brand.blue',
+        borderWidth: '2px',
+        borderColor: 'brand.blue',
+      }}
+      aria-selected={isSelected}
       width="full"
       onClick={onClick}
     >

--- a/src/app/ai/coach/_store/financialGoalSurveyStore.ts
+++ b/src/app/ai/coach/_store/financialGoalSurveyStore.ts
@@ -4,33 +4,22 @@ import { getCurrentTimestamp } from '@/src/client/utils/parser';
 
 export type Answer = Record<string, string | number>;
 
-interface financialGoalSurveyState {
+interface FinancialGoalSurveyState {
   response: Answer;
   isSubmitted: boolean;
   dateSubmitted: string | null;
   setResponse: (id: number, answer: string | number) => void;
   clearSurvey: () => void;
   submitSurvey: () => void;
-  isNotificationEnabled: boolean;
-  setNotification: (isNotificationEnabled: boolean) => void;
-  setScenarioCreated: () => void;
-  setPlanCreated: () => void;
-  setRoutineCreated: () => void;
-  dateScenarioCreated: string | null;
-  datePlanCreated: string | null;
-  dateRoutineCreated: string | null;
 }
 
-export const useFinancialGoalSurveyStore = create<financialGoalSurveyState>()(
+export const useFinancialGoalSurveyStore = create<FinancialGoalSurveyState>()(
   persist(
     (set) => ({
       response: {},
       isSubmitted: false,
       dateSubmitted: null,
-      isNotificationEnabled: false,
-      dateScenarioCreated: null,
-      datePlanCreated: null,
-      dateRoutineCreated: null,
+
       setResponse: (id, answer) =>
         set((state) => ({
           response: {
@@ -44,20 +33,6 @@ export const useFinancialGoalSurveyStore = create<financialGoalSurveyState>()(
         set({
           isSubmitted: true,
           dateSubmitted: getCurrentTimestamp(),
-        }),
-      setNotification: (isNotificationEnabled) =>
-        set({ isNotificationEnabled: isNotificationEnabled }),
-      setScenarioCreated: () =>
-        set({
-          dateScenarioCreated: getCurrentTimestamp(),
-        }),
-      setPlanCreated: () =>
-        set({
-          datePlanCreated: getCurrentTimestamp(),
-        }),
-      setRoutineCreated: () =>
-        set({
-          dateRoutineCreated: getCurrentTimestamp(),
         }),
     }),
     {

--- a/src/app/ai/coach/_store/generateAiSolutionStore.ts
+++ b/src/app/ai/coach/_store/generateAiSolutionStore.ts
@@ -1,0 +1,94 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { getCurrentTimestamp } from '@/src/client/utils/parser';
+
+type SectionKey = 'scenario' | 'plan' | 'routine';
+
+interface TimestampState {
+  requestedAt: string | null; // 알림받기 메시지 시간
+  createdAt: string | null; // 읽어보기 메시지 시간
+  notificationEnabled: boolean; // 알림받기 클릭 여부
+}
+
+interface GenerateAiSolutionState {
+  scenario: TimestampState;
+  plan: TimestampState;
+  routine: TimestampState;
+
+  setScenarioRequested: () => void;
+  setPlanRequested: () => void;
+  setRoutineRequested: () => void;
+
+  setScenarioCreated: () => void;
+  setPlanCreated: () => void;
+  setRoutineCreated: () => void;
+
+  setScenarioNotification: (enabled: boolean) => void;
+  setPlanNotification: (enabled: boolean) => void;
+  setRoutineNotification: (enabled: boolean) => void;
+}
+
+export const useGenerateAiSolutionStore = create<GenerateAiSolutionState>()(
+  persist(
+    (set, get) => {
+      const setIfNotExists = (
+        section: SectionKey,
+        key: keyof TimestampState,
+      ) => {
+        const current = get()[section][key];
+        if (!current) {
+          set((state) => ({
+            [section]: {
+              ...state[section],
+              [key]: getCurrentTimestamp(),
+            },
+          }));
+        }
+      };
+
+      const setNotification = (section: SectionKey, enabled: boolean) => {
+        set((state) => ({
+          [section]: {
+            ...state[section],
+            notificationEnabled: enabled,
+          },
+        }));
+      };
+
+      return {
+        scenario: {
+          requestedAt: null,
+          createdAt: null,
+          notificationEnabled: false,
+        },
+        plan: {
+          requestedAt: null,
+          createdAt: null,
+          notificationEnabled: false,
+        },
+        routine: {
+          requestedAt: null,
+          createdAt: null,
+          notificationEnabled: false,
+        },
+
+        setScenarioRequested: () => setIfNotExists('scenario', 'requestedAt'),
+        setPlanRequested: () => setIfNotExists('plan', 'requestedAt'),
+        setRoutineRequested: () => setIfNotExists('routine', 'requestedAt'),
+
+        setScenarioCreated: () => setIfNotExists('scenario', 'createdAt'),
+        setPlanCreated: () => setIfNotExists('plan', 'createdAt'),
+        setRoutineCreated: () => setIfNotExists('routine', 'createdAt'),
+
+        setScenarioNotification: (enabled) =>
+          setNotification('scenario', enabled),
+        setPlanNotification: (enabled) => setNotification('plan', enabled),
+        setRoutineNotification: (enabled) =>
+          setNotification('routine', enabled),
+      };
+    },
+    {
+      name: 'generate-ai-solution-store',
+    },
+  ),
+);

--- a/src/app/ai/coach/_store/generateAiSolutionStore.ts
+++ b/src/app/ai/coach/_store/generateAiSolutionStore.ts
@@ -88,7 +88,7 @@ export const useGenerateAiSolutionStore = create<GenerateAiSolutionState>()(
       };
     },
     {
-      name: 'generate-ai-solution-store',
+      name: 'generate-ai-solution-storage',
     },
   ),
 );

--- a/src/app/ai/coach/form/financial-goal/page.tsx
+++ b/src/app/ai/coach/form/financial-goal/page.tsx
@@ -1,32 +1,35 @@
 'use client';
 
-import { Box, Flex, Stack } from '@chakra-ui/react';
-import ProgressBar from '@/src/app/ai/coach/_components/form/ProgressBar';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Box, Flex, Stack } from '@chakra-ui/react';
+import Modal from '@/src/app/common/Modal/Modal';
+import ProgressBar from '@/src/app/ai/coach/_components/form/ProgressBar';
 import StepController from '@/src/app/ai/coach/_components/form/StepController';
 import Step from '@/src/app/ai/coach/_components/form/Step';
 import Question from '@/src/app/ai/coach/_components/form/Question';
 import Answer from '@/src/app/ai/coach/_components/form/Answer';
 import { financialGoalSurvey } from '@/src/app/ai/_constants/survey';
-import Modal from '@/src/app/common/Modal/Modal';
 import { useFinancialGoalSurveyStore } from '@/src/app/ai/coach/_store/financialGoalSurveyStore';
-import { useRouter } from 'next/navigation';
+import { useGenerateAiSolutionStore } from '@/src/app/ai/coach/_store/generateAiSolutionStore';
+import postAiContent from '@/src/client/lib/api/postAiContent';
 import postFinancialGoalSurvey from '@/src/client/lib/api/postFinancialGoalSurvey';
-import { useGenerateAiSolutionStore } from '@/src/app/ai/coach/_store/generateAISolutionStore';
+
 const totalStep = 12;
 
 function FinancialGoalFormPage() {
-  const router = useRouter();
   const [currentStep, setCurrentStep] = useState(1);
   const [isOpen, setIsOpen] = useState(false);
   const { setResponse, response, submitSurvey } = useFinancialGoalSurveyStore();
   const { setScenarioRequested } = useGenerateAiSolutionStore();
+  const router = useRouter();
 
   const handleConfirm = async () => {
     setIsOpen(false);
     submitSurvey();
     setScenarioRequested();
     await postFinancialGoalSurvey({ response });
+    await postAiContent({ contentType: 'SCENARIO' });
     router.push('/ai/coach');
   };
 

--- a/src/app/ai/coach/form/financial-goal/page.tsx
+++ b/src/app/ai/coach/form/financial-goal/page.tsx
@@ -12,6 +12,7 @@ import Modal from '@/src/app/common/Modal/Modal';
 import { useFinancialGoalSurveyStore } from '@/src/app/ai/coach/_store/financialGoalSurveyStore';
 import { useRouter } from 'next/navigation';
 import postFinancialGoalSurvey from '@/src/client/lib/api/postFinancialGoalSurvey';
+import { useGenerateAiSolutionStore } from '@/src/app/ai/coach/_store/generateAISolutionStore';
 const totalStep = 12;
 
 function FinancialGoalFormPage() {
@@ -19,10 +20,12 @@ function FinancialGoalFormPage() {
   const [currentStep, setCurrentStep] = useState(1);
   const [isOpen, setIsOpen] = useState(false);
   const { setResponse, response, submitSurvey } = useFinancialGoalSurveyStore();
+  const { setScenarioRequested } = useGenerateAiSolutionStore();
 
   const handleConfirm = async () => {
     setIsOpen(false);
     submitSurvey();
+    setScenarioRequested();
     await postFinancialGoalSurvey({ response });
     router.push('/ai/coach');
   };

--- a/src/app/ai/coach/page.tsx
+++ b/src/app/ai/coach/page.tsx
@@ -200,7 +200,7 @@ function CoachPage() {
       component: (
         <Flex align="flex-end" gap="8px" key="plan">
           <ChatbotMessage
-            message={`${user?.name}님의 재무 목표, 어떻게 이룰 수 있을까요? 현실 가능한 여러 가지 플랜을 제안드릴게요.`}
+            message={`${user?.name ? user.name : "회원"}님의 재무 목표, 어떻게 이룰 수 있을까요? 현실 가능한 여러 가지 플랜을 제안드릴게요.`}
             buttonText="읽어보기"
             onButtonClick={() => push('/ai/coach/plan')}
           />

--- a/src/app/ai/coach/page.tsx
+++ b/src/app/ai/coach/page.tsx
@@ -123,7 +123,7 @@ function CoachPage() {
             onButtonClick={() => push('/ai/coach/form/buy-home')}
             isDisabled={isBuyHomeSubmitted}
           />
-          <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+          <Text textStyle="mobile_cap" color="blue.600" whiteSpace="nowrap">
             {parseTimeFromTimestamp(dateFirstVisit)}
           </Text>
         </Flex>
@@ -140,7 +140,7 @@ function CoachPage() {
             onButtonClick={() => push('/ai/coach/form/financial-goal')}
             isDisabled={isFinancialGoalSubmitted}
           />
-          <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+          <Text textStyle="mobile_cap" color="blue.600" whiteSpace="nowrap">
             {parseTimeFromTimestamp(buyHomeDateSubmitted)}
           </Text>
         </Flex>
@@ -157,7 +157,7 @@ function CoachPage() {
             onButtonClick={() => handleGetNotification('scenario')}
             isDisabled={isScenarioNotificationEnabled}
           />
-          <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+          <Text textStyle="mobile_cap" color="blue.600" whiteSpace="nowrap">
             {parseTimeFromTimestamp(dateScenarioRequested)}
           </Text>
         </Flex>
@@ -172,7 +172,7 @@ function CoachPage() {
             buttonText="읽어보기"
             onButtonClick={() => push('/ai/coach/scenario')}
           />
-          <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+          <Text textStyle="mobile_cap" color="blue.600" whiteSpace="nowrap">
             {parseTimeFromTimestamp(dateScenarioCreated)}
           </Text>
         </Flex>
@@ -189,7 +189,7 @@ function CoachPage() {
             onButtonClick={() => handleGetNotification('plan')}
             isDisabled={isPlanNotificationEnabled}
           />
-          <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+          <Text textStyle="mobile_cap" color="blue.600" whiteSpace="nowrap">
             {parseTimeFromTimestamp(datePlanRequested)}
           </Text>
         </Flex>
@@ -200,11 +200,11 @@ function CoachPage() {
       component: (
         <Flex align="flex-end" gap="8px" key="plan">
           <ChatbotMessage
-            message={`${user?.name ? user.name : "회원"}님의 재무 목표, 어떻게 이룰 수 있을까요? 현실 가능한 여러 가지 플랜을 제안드릴게요.`}
+            message={`${user?.name ? user.name : '회원'}님의 재무 목표, 어떻게 이룰 수 있을까요? 현실 가능한 여러 가지 플랜을 제안드릴게요.`}
             buttonText="읽어보기"
             onButtonClick={() => push('/ai/coach/plan')}
           />
-          <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+          <Text textStyle="mobile_cap" color="blue.600" whiteSpace="nowrap">
             {parseTimeFromTimestamp(datePlanCreated)}
           </Text>
         </Flex>
@@ -221,7 +221,7 @@ function CoachPage() {
             onButtonClick={() => handleGetNotification('routine')}
             isDisabled={isRoutineNotificationEnabled}
           />
-          <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+          <Text textStyle="mobile_cap" color="blue.600" whiteSpace="nowrap">
             {parseTimeFromTimestamp(dateRoutineRequested)}
           </Text>
         </Flex>
@@ -236,7 +236,7 @@ function CoachPage() {
             buttonText="읽어보기"
             onButtonClick={() => push('/ai/coach/routine')}
           />
-          <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+          <Text textStyle="mobile_cap" color="blue.600" whiteSpace="nowrap">
             {parseTimeFromTimestamp(dateRoutineCreated)}
           </Text>
         </Flex>
@@ -253,7 +253,7 @@ function CoachPage() {
         <Box key={date}>
           <Flex align="center" gap="8px" my="12px">
             <Box borderBottom="1px solid" borderColor="blue.600" width="100%" />
-            <Text fontSize="sm" color="blue.600" whiteSpace="nowrap">
+            <Text textStyle="mobile_b2" color="blue.600" whiteSpace="nowrap">
               {formatKoreanDate(date)}
             </Text>
             <Box borderBottom="1px solid" borderColor="blue.600" width="100%" />

--- a/src/app/api/survey/route.ts
+++ b/src/app/api/survey/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ message: 'Survey API is working', status: 200 });
+}

--- a/src/app/api/survey/route.ts
+++ b/src/app/api/survey/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  return NextResponse.json({ message: 'Survey API is working', status: 200 });
+  await new Promise((resolve) => setTimeout(resolve, 5000)); 
+
+  return NextResponse.json({
+    error: 'This endpoint does not support GET requests.',
+    status: 200,
+  });
 }

--- a/src/client/constants/API.ts
+++ b/src/client/constants/API.ts
@@ -2,3 +2,5 @@ export const BASE_URL =
   process.env.NODE_ENV === 'production'
     ? 'https://www.jabbit.my/api'
     : 'http://localhost:3000/api';
+
+export const AI_API_URL = 'https://api.jabbit.my/api';

--- a/src/client/lib/api/getAiContent.ts
+++ b/src/client/lib/api/getAiContent.ts
@@ -1,0 +1,17 @@
+import { AI_API_URL } from '@/src/client/constants/API';
+
+
+type ContentPayload = 'SCENARIO' | 'PLAN' | 'ROUTINE';
+
+const getAiContent = async (payload: ContentPayload) => {
+  const response = await fetch(`${AI_API_URL}/ai/content/${payload}`, {
+    method: 'GET',
+    next: {
+      revalidate: 3600,
+    },
+  });
+
+  return await response.json();
+};
+
+export default getAiContent;

--- a/src/client/lib/api/getAiScenario.ts
+++ b/src/client/lib/api/getAiScenario.ts
@@ -1,0 +1,14 @@
+import { BASE_URL } from '@/src/server/constants/API';
+
+const getAiScenario = async () => {
+  const response = await fetch(`/api/survey`, {
+    method: 'GET',
+    next: {
+      revalidate: 3600,
+    },
+  });
+
+  return await response.json();
+};
+
+export default getAiScenario;

--- a/src/client/lib/api/getAiScenario.ts
+++ b/src/client/lib/api/getAiScenario.ts
@@ -1,5 +1,3 @@
-import { BASE_URL } from '@/src/server/constants/API';
-
 const getAiScenario = async () => {
   const response = await fetch(`/api/survey`, {
     method: 'GET',

--- a/src/client/lib/api/postAiContent.ts
+++ b/src/client/lib/api/postAiContent.ts
@@ -1,20 +1,24 @@
 import { AI_API_URL } from '@/src/client/constants/API';
 
-const postFinancialGoalSurvey = async (survey: {
-  response: Record<string, string | number>;
-}) => {
-  const response = await fetch(`${AI_API_URL}/survey?type=add-routine-info`, {
+interface NotificationPayload {
+  contentType: 'SCENARIO' | 'PLAN' | 'ROUTINE';
+}
+
+const postAiContent = async (payload: NotificationPayload) => {
+  const response = await fetch(`${AI_API_URL}/ai/content`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(survey),
+    body: JSON.stringify(payload),
   });
+
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.error || 'Failed to create user');
   }
+
   return (await response.json()).data;
 };
 
-export default postFinancialGoalSurvey;
+export default postAiContent;

--- a/src/client/lib/api/postAiContentNotification.ts
+++ b/src/client/lib/api/postAiContentNotification.ts
@@ -1,0 +1,25 @@
+import { AI_API_URL } from '@/src/client/constants/API';
+
+interface NotificationPayload {
+  contentType: 'SCENARIO' | 'PLAN' | 'ROUTINE';
+  isAgreed: boolean;
+}
+
+const postAiContentNotification = async (payload: NotificationPayload) => {
+  const response = await fetch(`${AI_API_URL}/ai/content/notification`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to create user');
+  }
+
+  return (await response.json()).data;
+};
+
+export default postAiContentNotification;

--- a/src/client/lib/api/postBuyHomeSurvey.ts
+++ b/src/client/lib/api/postBuyHomeSurvey.ts
@@ -1,10 +1,13 @@
-import { BASE_URL } from '@/src/server/constants/API';
+import { AI_API_URL } from '@/src/client/constants/API';
 
 const postBuyHomeSurvey = async (survey: {
   response: Record<string, string | number>;
 }) => {
-  const response = await fetch(`${BASE_URL}/survey?type=house-goal`, {
+  const response = await fetch(`${AI_API_URL}/survey?type=house-goal`, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(survey),
   });
 

--- a/src/client/utils/parser.ts
+++ b/src/client/utils/parser.ts
@@ -75,7 +75,7 @@ export const extractDateOnly = (timestamp?: string): string => {
 };
 export const formatKoreanDate = (dateString: string) => {
   const [, month, day] = dateString.split('-');
-  return `${Number(month)}월 ${Number(day)}일`;
+  return `${month}월 ${day}일`;
 };
 
 export const groupMessagesByDate = (


### PR DESCRIPTION
### 개요

- closes issue #82 

---

### 작업 내용

- [X] API 연동 
장기 재무 목표 설정 응답 제출 (POST)
추가 정보 수집 응답 제출 (POST)
알림 받기 (POST) – 시나리오, 루틴, 플랜
AI 컨텐츠 생성 요청 (POST) – 시나리오, 루틴, 플랜
AI 컨텐츠 조회(GET) – 시나리오, 루틴, 플랜
- [X] AI 컨텐츠 생성 로딩 type writing 효과
- [X] 챗봇 메시지 조건부 분기 추가

---

### 스크린샷

---

### 참고
혜리님 말씀하신 패딩 영역 추가했고, tanstack query 는 아직 적용 안된 상태입니다! 이후 테스트하면서 개선 시켜볼게요~!